### PR TITLE
allow working directory to be beneath /tmp

### DIFF
--- a/squilt
+++ b/squilt
@@ -32,12 +32,6 @@ envar: "HOME=$HOME"
 envar: "PATH=$PATH"
 
 mount {
-        src: "$mount_dir"
-        dst: "$mount_dir"
-        rw: true
-        is_bind: true
-}
-mount {
         src: "/bin"
         dst: "/bin"
         rw: false
@@ -109,6 +103,12 @@ mount {
         fstype: "tmpfs"
         rw: true
         is_bind: false
+}
+mount {
+        src: "$mount_dir"
+        dst: "$mount_dir"
+        rw: true
+        is_bind: true
 }
 mount {
         dst: "$HOME/rpmbuild"


### PR DESCRIPTION
When trying to run squilt in a package checkout in /tmp then the
invocation fails, because the mount of the working directory in the
target namespace is no longer visible due to the /tmp directory being
replaced by a private tmp mount.

By moving the directive for the working directory to the end of the
config file things seem to work out correctly again.

Hopefully this does not change anything with regards to the
sandboxing properties. Please double check. Thanks!