### PR TITLE
squilt: add ld.so.cache for libraries in non-standard locations

### DIFF
--- a/squilt
+++ b/squilt
@@ -87,6 +87,12 @@ mount {
         is_bind: true
 }
 mount {
+        src: "/etc/ld.so.cache"
+        dst: "/etc/ld.so.cache"
+        rw: false
+        is_bind: true
+}
+mount {
         src: "/etc/rpm"
         dst: "/etc/rpm"
         rw: false


### PR DESCRIPTION
New rpmbuild requires libgomp from /usr/lib/gcc/x86_64-pc-linux-gnu/...
which is not found unless ld.so.cache is around.